### PR TITLE
Add BufSurfClear to clean the navigation history

### DIFF
--- a/doc/bufsurf.txt
+++ b/doc/bufsurf.txt
@@ -72,6 +72,10 @@ issue:
 
   :BufSurfList
 
+And finally, to clean the navigation history:
+
+  :BufSurfClear
+
 
 OPTIONS                                                      *bufsurf-options*
 

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -20,12 +20,19 @@ call s:InitVariable('g:BufSurfMessages', 1)
 command BufSurfBack :call <SID>BufSurfBack()
 command BufSurfForward :call <SID>BufSurfForward()
 command BufSurfList :call <SID>BufSurfList()
+command BufSurfClear :call <SID>BufSurfClear()
 
 " List of buffer names that we should not track.
 let s:ignore_buffers = split(g:BufSurfIgnore, ',')
 
-" Indicates whether the plugin is enabled or not. 
+" Indicates whether the plugin is enabled or not.
 let s:disabled = 0
+
+" Clear the navigation history
+function s:BufSurfClear()
+    let w:history_index = 0
+    let w:history = []
+endfunction
 
 " Open the previous buffer in the navigation history for the current window.
 function s:BufSurfBack()

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -30,7 +30,7 @@ let s:disabled = 0
 
 " Clear the navigation history
 function s:BufSurfClear()
-    let w:history_index = 0
+    let w:history_index = -1
     let w:history = []
 endfunction
 


### PR DESCRIPTION
Context:

I have a huge project and I'm switching to files a lot, fixing multiple issues a day. Every time I start working on new issue, I remove all my buffers:

```vim
bufdo bw
```

However, even though BufSurf [has autocmd to clean the buffers from history](https://github.com/ton/vim-bufsurf/blob/e996c94000dc44a66e5c5d27bd24364d23839ac9/plugin/bufsurf.vim#L160), when buffers are wiped out using the command above, some of them are still in history. (Honestly don't know why, not a vim expert)

My solution is to add BufSurfClear command, and then when I remove all my buffers, I clear the history as well:

```vim
bufdo bw | BufSurfClear
```

That solves the problem for me. I did that as a quick hack to solve my particular needs, and I understand that you may not be interested for this change to be commited (after all, bufsurf should always work as expected and clear the buffers from history without having to manually clean anything). Nevertheless, I did create the PR to add this command to the plugin in the case that the maintaners need it.