### PR TITLE
Added persistent option to share history across all windows

### DIFF
--- a/doc/bufsurf.txt
+++ b/doc/bufsurf.txt
@@ -99,6 +99,11 @@ The following is a list of all available options:
         Indicates whether BufSurf (warning) messages should be displayed.
 
 
+    g:BufSurfPersistent              Boolean value; either 0 or 1 (default: 0)
+
+        This allows all windows to share the same history. 
+
+
 LICENSE                                                      *bufsurf-license*
 
 Copyright 2010-2012 Ton van den Heuvel. All rights reserved.


### PR DESCRIPTION
I wanted to match Emacs' next-buffer and previous-buffer.  Setting the new option g:BufSurfPersistent to 1 allows all windows to share the same history.   I usually have quite a few windows open, having different histories for each one is a bit too chaotic for me.

I'm not a Vim scripter so there is most likely a more elegant way to do this.  Feel free to critique or toss out.