### PR TITLE
Added more history options

### DIFF
--- a/doc/bufsurf.txt
+++ b/doc/bufsurf.txt
@@ -99,6 +99,16 @@ The following is a list of all available options:
         Indicates whether BufSurf (warning) messages should be displayed.
 
 
+    |g:BufSurfHistory|              Int value; (default: 15)
+
+        Limits history to x number of entries by pruning the oldest 
+        references based on the current position in the index.
+
+    |g:BufSurfPersistence|              Int value; (default: 15) (default: 0)
+        
+        Indicates whether history is shared between windows. 
+        
+
 LICENSE                                                      *bufsurf-license*
 
 Copyright 2010-2012 Ton van den Heuvel. All rights reserved.

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -16,6 +16,8 @@ endfunction
 
 call s:InitVariable('g:BufSurfIgnore', '')
 call s:InitVariable('g:BufSurfMessages', 1)
+call s:InitVariable('g:BufSurfHistory', 35)
+call s:InitVariable('g:BufSurfPersistent', 0)
 
 command BufSurfBack :call <SID>BufSurfBack()
 command BufSurfForward :call <SID>BufSurfForward()
@@ -27,15 +29,25 @@ let s:ignore_buffers = split(g:BufSurfIgnore, ',')
 
 " Indicates whether the plugin is enabled or not.
 let s:disabled = 0
+let s:history = []
 
 " Clear the navigation history
 function s:BufSurfClear()
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     let w:history_index = -1
     let w:history = []
+
+    " Determine prefix 
+    call s:BufSurfPersist("save")
 endfunction
 
 " Open the previous buffer in the navigation history for the current window.
 function s:BufSurfBack()
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     if w:history_index > 0
         let w:history_index -= 1
         let s:disabled = 1
@@ -44,10 +56,16 @@ function s:BufSurfBack()
     else
         call s:BufSurfEcho("reached start of window navigation history")
     endif
+
+    " Determine prefix 
+    call s:BufSurfPersist("save")
 endfunction
 
 " Open the next buffer in the navigation history for the current window.
 function s:BufSurfForward()
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     if w:history_index < len(w:history) - 1
         let w:history_index += 1
         let s:disabled = 1
@@ -56,11 +74,17 @@ function s:BufSurfForward()
     else
         call s:BufSurfEcho("reached end of window navigation history")
     endif
+
+    " Determine prefix 
+    call s:BufSurfPersist("save")
 endfunction
 
 " Add the given buffer number to the navigation history for the window
 " identified by winnr.
 function s:BufSurfAppend(bufnr)
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     " In case the specified buffer should be ignored, do not append it to the
     " navigation history of the window.
     if s:BufSurfIsDisabled(a:bufnr)
@@ -91,6 +115,7 @@ function s:BufSurfAppend(bufnr)
     " Add the current buffer to the buffer navigation history list of the
     " current window.
     else
+        call s:BufSurfTrim()
         let w:history_index += 1
     endif
 
@@ -104,10 +129,16 @@ function s:BufSurfAppend(bufnr)
     if !l:is_buffer_listed
         let w:history = insert(w:history, a:bufnr, w:history_index)
     endif
+
+    " Determine prefix 
+    call s:BufSurfPersist("save")
 endfunction
 
 " Displays buffer navigation history for the current window.
 function s:BufSurfList()
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     let l:buffer_names = []
     for l:bufnr in w:history
         let l:buffer_name = bufname(l:bufnr)
@@ -139,6 +170,9 @@ endfunction
 
 " Remove buffer with number bufnr from all navigation histories.
 function s:BufSurfDelete(bufnr)
+    " Determine prefix 
+    call s:BufSurfPersist("load")
+
     if s:BufSurfIsDisabled(a:bufnr)
         return
     endif
@@ -150,6 +184,9 @@ function s:BufSurfDelete(bufnr)
     if w:history_index >= len(w:history)
         let w:history_index = len(w:history) - 1
     endif
+
+    " Determine prefix 
+    call s:BufSurfPersist("save")
 endfunction
 
 " Echo a BufSurf message in the Vim status line.
@@ -162,6 +199,40 @@ function s:BufSurfEcho(msg)
           echomsg l
         endfor
         echohl None
+    endif
+endfunction
+
+" Persistent Handler
+function s:BufSurfPersist(act)
+    if g:BufSurfPersistent
+        if a:act == "load"
+            if len(s:history) > 0
+                let w:history_index = s:history_index
+                let w:history = s:history
+            endif
+        elseif a:act == "save"
+            let s:history_index = w:history_index
+            let s:history = w:history
+        endif
+    endif
+endfunction
+
+" Keeps buffer history manageable since we're sharing it between windows
+function s:BufSurfTrim()
+    if g:BufSurfHistory && len(w:history) > g:BufSurfHistory - 1
+        let l:marker = len(w:history) - g:BufSurfHistory + 1
+        if w:history_index < len(w:history) / 3 
+            let l:limit = g:BufSurfHistory - 2
+            if l:limit <= 0
+                " for a history setting of one
+                let w:history = w:history[0]
+            else
+                let w:history = w:history[0:l:limit]
+            endif
+        else
+            let w:history = w:history[l:marker:]
+            let w:history_index = w:history_index - l:marker           
+        endif        
     endif
 endfunction
 


### PR DESCRIPTION
Adds two new options to manage history.

**g:BufSurfHistory**: Limits history to x number of entries by pruning the oldest references based on the current position in the index.

**g:BufSurfPersistence**:  Indicates whether history is shared between windows. 
