### PR TITLE
Fix BufWipeout targeting wrong buffer number

### DIFF
--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -170,5 +170,5 @@ augroup BufSurf
   autocmd!
   autocmd BufEnter * :call s:BufSurfAppend(winbufnr(winnr()))
   autocmd WinEnter * :call s:BufSurfAppend(winbufnr(winnr()))
-  autocmd BufWipeout * :call s:BufSurfDelete(winbufnr(winnr()))
+  autocmd BufWipeout * :call s:BufSurfDelete(str2nr(expand('<abuf>')))
 augroup End


### PR DESCRIPTION
From document of [BufWipeout](http://vimdoc.sourceforge.net/htmldoc/autocmd.html#BufWipeout):
```
NOTE: When this autocommand is executed, the current buffer "%" may be different from the buffer being deleted "<afile>".
```

This can happen when, for example, using neovim's floating window.

To correctly get the buffer being deleted, it should call BufSurfDelete with [\<abuf\>](http://vimdoc.sourceforge.net/htmldoc/cmdline.html#%3Cabuf%3E).