### PR TITLE
Properly remove deleted buffers from ALL histories

### DIFF
--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -143,13 +143,36 @@ function s:BufSurfDelete(bufnr)
         return
     endif
 
-    " Remove the buffer from all window histories.
-    call filter(w:history, 'v:val !=' . a:bufnr)
+    " Go into each window of each tab and remove the buffer from each window's history
+    for tab_info in gettabinfo()
+        for win_idx in tab_info.windows
+            let history = gettabwinvar(tab_info.tabnr, win_idx, 'history')
+            if type(history) != v:t_list
+                continue
+            endif
+            let history_index = gettabwinvar(tab_info.tabnr, win_idx, 'history_index')
 
-    " In case the current window history index is no longer valid, move it within boundaries.
-    if w:history_index >= len(w:history)
-        let w:history_index = len(w:history) - 1
-    endif
+            call filter(history, 'v:val != ' . a:bufnr)
+            " Remove duplicate buffers that have been made adjacent from the deletion
+            let remove_index = 0
+            while remove_index < len(history) - 1
+                if history[remove_index] == history[remove_index + 1]
+                    call remove(history, remove_index)
+                    " Stay at the current index
+                    let remove_index -= 1
+                endif
+
+                let remove_index += 1
+            endwhile
+            call settabwinvar(tab_info.tabnr, win_idx, 'history', history)
+
+            " In case the current window history index is no longer valid, move it within boundaries.
+            if history_index >= len(history)
+                let history_index = len(history) - 1
+                call settabwinvar(tab_info.tabnr, win_idx, 'history_index', history_index)
+            endif
+        endfor
+    endfor
 endfunction
 
 " Echo a BufSurf message in the Vim status line.


### PR DESCRIPTION
Goes into the `w:` dict of every window and performs the deletion for each window. Also fixes a bug where if you had a history like

`A B A`

and you deleted `B` you'd be left with the history

`A A`

which is obviously incorrect. Now deletes adjacent duplicate history entries after deletion.