### PR TITLE
Add BufSurfListAll to list bufs in each tab/window

### DIFF
--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -113,9 +113,9 @@ function s:BufSurfList()
     for l:bufnr in w:history
         let l:buffer_name = bufname(l:bufnr)
         if bufnr("%") == l:bufnr
-            let l:buffer_name = "*>" . l:buffer_name
+            let l:buffer_name = "* >" . l:buffer_name
         else
-            let l:buffer_name = " >" . l:buffer_name
+            let l:buffer_name = "  >" . l:buffer_name
         endif
         let l:buffer_names = l:buffer_names + [l:buffer_name]
     endfor

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -122,6 +122,7 @@ function s:BufSurfList()
     call s:BufSurfEcho("window buffer navigation history (* = current):" . join(l:buffer_names, "\n"))
 endfunction
 
+" Displays buffer navigation history for all windows in all tabs.
 function s:BufSurfListAll()
     let name_lines = []
 

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -129,9 +129,9 @@ function s:BufSurfListAll()
         for win_id in tab_info.windows
             call add(name_lines, '')
             if win_getid() == win_id
-                let cur_str = '*>'
+                let cur_str = '* >'
             else
-                let cur_str = ' >'
+                let cur_str = '  >'
             endif
             let fmt_win = cur_str . 'tab: ' . tab_info.tabnr . ' window: ' . win_id2win(win_id)
             call add(name_lines, fmt_win)
@@ -146,9 +146,9 @@ function s:BufSurfListAll()
             for hist_idx in range(len(history))
                 let name = bufname(history[hist_idx])
                 if history_index == hist_idx
-                    let cur_str = '  *>'
+                    let cur_str = '  * >'
                 else
-                    let cur_str = '   >'
+                    let cur_str = '    >'
                 endif
                 let fmt_name = cur_str . name
                 call add(name_lines, fmt_name)


### PR DESCRIPTION
Example output:

```
BufSurf: window buffer nav hist (* = current):
 >tab: 1 window: 0
   >
   >package.json
   >pom.xml
   >package.json
   >install_core.cmd
  *>package.json

 >tab: 2 window: 1
   >package.json
   >
   >CHANGELOG.md
   >package.json
  *>CONTRIBUTING.md
   >pom.xml
   >install_core.cmd

*>tab: 2 window: 2
   >CONTRIBUTING.md
  *>CHANGELOG.md
   >deps
```

Added a `>` before the buffer name because unnamed buffers (like when you open a new tab) were just an empty line. Changed `BufSurfList` to also use `>` before the name.