### PR TITLE
Add <Plug> mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ then `:bp(revious)` in the last buffer (containing `B`) would open up buffer
 `A`, where `C` is preferable. This plugin supplies the user with the commands
 `:BufSurfForward` and `:BufSurfBack` to navigate buffers forwards and backwards
 according to the navigation history.
+
+It also provides `<Plug>` mappings:
+
+```vimL
+nmap ]b <Plug>(buf-surf-forward)
+nmap [b <Plug>(buf-surf-back)
+```

--- a/plugin/bufsurf.vim
+++ b/plugin/bufsurf.vim
@@ -22,6 +22,9 @@ command BufSurfForward :call <SID>BufSurfForward()
 command BufSurfList :call <SID>BufSurfList()
 command BufSurfClear :call <SID>BufSurfClear()
 
+nnoremap <silent> <Plug>(buf-surf-back) :BufSurfBack<CR>
+nnoremap <silent> <Plug>(buf-surf-forward) :BufSurfForward<CR>
+
 " List of buffer names that we should not track.
 let s:ignore_buffers = split(g:BufSurfIgnore, ',')
 


### PR DESCRIPTION
Just adds mappings for `<Plug>(buf-surf-forward)` and `<Plug>(buf-surf-back)` since they are a bit nicer to use than commands.